### PR TITLE
feat: per-profile spotlight pages + news hook / source URL split

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { createClient } from '@supabase/supabase-js'
+import { getEverySpotlight, slugifyName } from '@/lib/queries'
 
 export const revalidate = 3600
 
@@ -27,5 +28,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }))
 
-  return [...staticPages, ...blogUrls]
+  // Every spotlight profile ever featured gets a permanent indexable URL.
+  // Uses the shared slugifyName helper to stay in sync with the route handler.
+  const allSpotlights = await getEverySpotlight()
+  const spotlightUrls: MetadataRoute.Sitemap = allSpotlights.map(s => ({
+    url: `https://into.tax/spotlight/${slugifyName(s.person_name)}`,
+    lastModified: s.issue_date ? new Date(s.issue_date) : new Date(),
+    changeFrequency: 'yearly',
+    priority: 0.7,
+  }))
+
+  return [...staticPages, ...blogUrls, ...spotlightUrls]
 }

--- a/app/spotlight/[slug]/page.tsx
+++ b/app/spotlight/[slug]/page.tsx
@@ -1,0 +1,148 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { Masthead } from "@/components/masthead"
+import { DeadlineTicker } from "@/components/deadline-ticker"
+import { SpotlightCard } from "@/components/spotlight-card"
+import { getSpotlightBySlug, getKeyDates, slugifyName } from "@/lib/queries"
+
+export const revalidate = 0
+export const dynamic = 'force-dynamic'
+
+type RouteParams = { params: Promise<{ slug: string }> }
+
+export async function generateMetadata({ params }: RouteParams) {
+  const { slug } = await params
+  const spotlight = await getSpotlightBySlug(slug)
+
+  if (!spotlight) {
+    return {
+      title: "Spotlight not found | into.tax",
+    }
+  }
+
+  const title = `${spotlight.person_name} \u00B7 into.tax Spotlight`
+  const description = spotlight.headline
+    || `${spotlight.person_name}, ${spotlight.job_title}${spotlight.firm ? ` at ${spotlight.firm}` : ''}.`
+  const canonical = `https://into.tax/spotlight/${slug}`
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: "into.tax",
+      type: "profile",
+      images: [
+        {
+          url: "https://into.tax/og-image.png",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["https://into.tax/og-image.png"],
+    },
+  }
+}
+
+function formatIssueDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  const day = date.getUTCDate()
+  const month = date.toLocaleDateString("en-GB", { month: "long", timeZone: "UTC" })
+  const year = date.getUTCFullYear()
+  return `${day} ${month} ${year}`
+}
+
+export default async function SpotlightProfilePage({ params }: RouteParams) {
+  const { slug } = await params
+  const [spotlight, keyDates] = await Promise.all([
+    getSpotlightBySlug(slug),
+    getKeyDates(),
+  ])
+
+  if (!spotlight) {
+    notFound()
+  }
+
+  // Build schema.org/Person JSON-LD
+  const personJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: spotlight.person_name,
+    jobTitle: spotlight.job_title,
+    worksFor: spotlight.firm
+      ? { "@type": "Organization", name: spotlight.firm }
+      : undefined,
+    knowsAbout: spotlight.specialism || undefined,
+    description: spotlight.paragraph,
+    url: `https://into.tax/spotlight/${slug}`,
+    sameAs: spotlight.linkedin_url ? [spotlight.linkedin_url] : undefined,
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FDFCFA]">
+      <Masthead />
+      <DeadlineTicker dates={keyDates} />
+
+      {/* schema.org/Person JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+
+      <main className="max-w-4xl mx-auto px-4 py-16">
+        {/* Breadcrumb back link */}
+        <div className="mb-8">
+          <Link
+            href="/spotlight"
+            className="text-[12px] font-mono text-[#8B7B6B] hover:text-[#A0522D] transition-colors"
+          >
+            &larr; Back to all Spotlights
+          </Link>
+        </div>
+
+        {/* Page Header */}
+        <header className="mb-10">
+          <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-[#A0522D] mb-3">
+            In the Spotlight &middot; {formatIssueDate(spotlight.issue_date)}
+          </p>
+          <h1 className="text-[32px] md:text-[38px] font-serif font-bold text-[#1C1412] tracking-tight leading-tight">
+            {spotlight.person_name}
+          </h1>
+          <div className="w-24 h-[3px] bg-[#A0522D] mt-6" />
+        </header>
+
+        {/* Full card */}
+        <SpotlightCard
+          spotlight={spotlight}
+          slug={slug}
+          standalone
+        />
+
+        <div className="mt-16 pt-8 border-t border-[#E8DFD6] text-center">
+          <Link
+            href="/"
+            className="text-[12px] font-mono text-[#8B7B6B] hover:text-[#A0522D] transition-colors"
+          >
+            &larr; Back to into.tax
+          </Link>
+        </div>
+      </main>
+
+      <footer className="border-t border-[#E8DFD6] py-8 bg-[#FDFCFA]">
+        <div className="max-w-4xl mx-auto px-4 text-center text-[11px] font-mono text-[#8B7B6B]">
+          into.tax &middot; UK Tax Intelligence &middot; {new Date().getFullYear()}
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/spotlight/page.tsx
+++ b/app/spotlight/page.tsx
@@ -1,10 +1,10 @@
-import { getAllSpotlights, Spotlight } from "@/lib/queries"
+import { getAllSpotlights, Spotlight, slugifyName } from "@/lib/queries"
 import { Masthead } from "@/components/masthead"
 import { DeadlineTicker } from "@/components/deadline-ticker"
 import { getKeyDates } from "@/lib/queries"
 import Link from "next/link"
-import { Linkedin } from "lucide-react"
-import { SpotlightShareButtons, ShareThisWeekButton } from "@/components/spotlight-share"
+import { ShareThisWeekButton } from "@/components/spotlight-share"
+import { SpotlightCard } from "@/components/spotlight-card"
 import { ScrollToHash } from "@/components/scroll-to-hash"
 
 export const revalidate = 0
@@ -13,11 +13,11 @@ export const dynamic = 'force-dynamic'
 export async function generateMetadata() {
   const spotlights = await getAllSpotlights()
   const latestWeek = spotlights.slice(0, 5)
-  
+
   if (latestWeek.length > 0) {
     const names = latestWeek.map(s => s.person_name)
     const description = `This week's into.tax In the Spotlight features ${names.join(", ")}.`
-    
+
     return {
       title: "In the Spotlight | into.tax",
       description,
@@ -43,18 +43,11 @@ export async function generateMetadata() {
       },
     }
   }
-  
+
   return {
     title: "In the Spotlight | into.tax",
     description: "Five UK tax professionals doing work that matters.",
   }
-}
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
 }
 
 function groupByIssueDate(spotlights: Spotlight[]): Record<string, Spotlight[]> {
@@ -81,9 +74,10 @@ export default async function SpotlightArchivePage() {
     getAllSpotlights(),
     getKeyDates(),
   ])
+
   const grouped = groupByIssueDate(spotlights)
   const sortedDates = Object.keys(grouped).sort((a, b) => b.localeCompare(a))
-  
+
   // Get this week's spotlights for the share button
   const thisWeekSpotlights = sortedDates.length > 0 ? grouped[sortedDates[0]] : []
 
@@ -92,7 +86,7 @@ export default async function SpotlightArchivePage() {
       <ScrollToHash />
       <Masthead />
       <DeadlineTicker dates={keyDates} />
-      
+
       <main className="max-w-4xl mx-auto px-4 py-16">
         {/* Page Header */}
         <header className="text-center mb-12">
@@ -103,7 +97,7 @@ export default async function SpotlightArchivePage() {
             Five UK tax professionals doing work that matters.
           </p>
           <div className="w-24 h-[3px] bg-[#A0522D] mx-auto mt-6" />
-          
+
           {/* Share this week's spotlight button */}
           {thisWeekSpotlights.length > 0 && (
             <div className="mt-8">
@@ -123,94 +117,15 @@ export default async function SpotlightArchivePage() {
                 <h2 className="text-[11px] font-mono uppercase tracking-[0.2em] text-[#A0522D] mb-8 pb-3 border-b border-[#E8DFD6]">
                   {formatWeekOf(date)}
                 </h2>
+
                 <div className="flex flex-col gap-8">
-                  {grouped[date].map((s) => {
-                    const slug = slugify(s.person_name)
-                    return (
-                      <article
-                        key={s.id}
-                        id={slug}
-                        className="relative bg-[#FFFDF9] rounded-lg p-8 md:p-10 shadow-[0_2px_12px_rgba(0,0,0,0.06)] overflow-hidden scroll-mt-32"
-                      >
-                        {/* Decorative quotation mark */}
-                        <div 
-                          className="absolute top-4 right-6 text-[120px] font-serif text-[#F5E6D8] leading-none pointer-events-none select-none"
-                          aria-hidden="true"
-                        >
-                          "
-                        </div>
-                        
-                        <div className="relative">
-                          {/* Name */}
-                          <h3 className="text-[24px] font-serif font-bold text-[#1C1412] leading-tight">
-                            {s.person_name}
-                          </h3>
-                          
-                          {/* Headline as pull quote */}
-                          {s.headline && (
-                            <p className="text-[16px] italic text-[#A0522D] mt-2 leading-snug">
-                              {s.headline}
-                            </p>
-                          )}
-                          
-                          {/* Metadata bar */}
-                          <p className="text-[11px] font-mono text-[#8B7B6B] mt-4 flex flex-wrap items-center gap-1.5">
-                            <span>{s.job_title}</span>
-                            {s.firm && (
-                              <>
-                                <span className="text-[#C4B5A5]">·</span>
-                                <span>{s.firm}</span>
-                              </>
-                            )}
-                            {s.specialism && (
-                              <>
-                                <span className="text-[#C4B5A5]">·</span>
-                                <span>{s.specialism}</span>
-                              </>
-                            )}
-                          </p>
-                          
-                          {/* Profile section */}
-                          <div className="mt-6">
-                            <h4 className="text-[11px] font-mono uppercase tracking-wider text-[#8B7B6B] mb-2">
-                              Profile
-                            </h4>
-                            <p className="text-[14px] font-sans text-[#3D3530] leading-[1.7]">
-                              {s.paragraph}
-                            </p>
-                          </div>
-                          
-                          {/* Source evidence - styled as highlighted callout */}
-                          {s.source_evidence && (
-                            <div className="mt-6 bg-[#F5F0EA] border-l-4 border-[#A0522D] rounded-r-md p-4">
-                              <h4 className="text-[11px] font-mono uppercase tracking-wider text-[#6B5B4F] mb-2">
-                                Why they're in the spotlight
-                              </h4>
-                              <p className="text-[13px] font-sans italic text-[#5A4A3A] leading-relaxed">
-                                {s.source_evidence}
-                              </p>
-                            </div>
-                          )}
-                          
-                          {/* LinkedIn profile link */}
-                          {s.linkedin_url && (
-                            <a
-                              href={s.linkedin_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1.5 mt-6 text-[12px] font-mono text-[#0A66C2] hover:text-[#004182] transition-colors"
-                            >
-                              <Linkedin className="w-4 h-4" />
-                              <span>View on LinkedIn</span>
-                            </a>
-                          )}
-                          
-                          {/* Share buttons */}
-                          <SpotlightShareButtons spotlight={s} slug={slug} />
-                        </div>
-                      </article>
-                    )
-                  })}
+                  {grouped[date].map((s) => (
+                    <SpotlightCard
+                      key={s.id}
+                      spotlight={s}
+                      slug={slugifyName(s.person_name)}
+                    />
+                  ))}
                 </div>
               </section>
             ))}

--- a/components/spotlight-card.tsx
+++ b/components/spotlight-card.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link"
 import { Linkedin } from "lucide-react"
 import { SpotlightShareButtons } from "@/components/spotlight-share"
 import type { Spotlight } from "@/lib/queries"
@@ -133,18 +132,6 @@ export function SpotlightCard({ spotlight: s, slug, standalone = false }: Props)
 
         {/* Share buttons */}
         <SpotlightShareButtons spotlight={s} slug={slug} />
-
-        {/* Permanent link to dedicated profile page (only shown on archive view) */}
-        {!standalone && (
-          <div className="mt-4 pt-3 border-t border-[#F0E8E0]">
-            <Link
-              href={`/spotlight/${slug}`}
-              className="text-[11px] font-mono text-[#8B7B6B] hover:text-[#A0522D] transition-colors"
-            >
-              View full profile &rarr;
-            </Link>
-          </div>
-        )}
       </div>
     </article>
   )

--- a/components/spotlight-card.tsx
+++ b/components/spotlight-card.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link"
+import { Linkedin } from "lucide-react"
+import { SpotlightShareButtons } from "@/components/spotlight-share"
+import type { Spotlight } from "@/lib/queries"
+
+/**
+ * Extract a clean display hostname from a URL (strips protocol + leading www).
+ * Returns the original string if parsing fails.
+ */
+function domainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "")
+  } catch {
+    return url
+  }
+}
+
+type Props = {
+  spotlight: Spotlight
+  slug: string
+  /**
+   * When true, renders as a standalone <article> suitable for dedicated /spotlight/[slug] pages.
+   * When false (default), renders inline for the archive index — preserves id={slug} anchor
+   * for backwards-compatibility with existing /spotlight#slug share links.
+   */
+  standalone?: boolean
+}
+
+export function SpotlightCard({ spotlight: s, slug, standalone = false }: Props) {
+  // Precedence: news_hook_url > source_evidence > hide
+  const primaryUrl = s.news_hook_url || s.source_evidence
+  const primaryLabel = s.news_hook_url
+    ? (s.news_hook_label || domainFromUrl(s.news_hook_url))
+    : (s.source_evidence ? domainFromUrl(s.source_evidence) : null)
+
+  // Show secondary source line only when source_evidence is distinct from news_hook_url
+  const showSecondarySource =
+    !!s.source_evidence && !!s.news_hook_url && s.source_evidence !== s.news_hook_url
+
+  return (
+    <article
+      id={standalone ? undefined : slug}
+      className="relative bg-[#FFFDF9] rounded-lg p-8 md:p-10 shadow-[0_2px_12px_rgba(0,0,0,0.06)] overflow-hidden scroll-mt-32"
+    >
+      {/* Decorative quotation mark */}
+      <div
+        className="absolute top-4 right-6 text-[120px] font-serif text-[#F5E6D8] leading-none pointer-events-none select-none"
+        aria-hidden="true"
+      >
+        &ldquo;
+      </div>
+
+      <div className="relative">
+        {/* Name */}
+        <h3 className="text-[24px] font-serif font-bold text-[#1C1412] leading-tight">
+          {s.person_name}
+        </h3>
+
+        {/* Headline as pull quote */}
+        {s.headline && (
+          <p className="text-[16px] italic text-[#A0522D] mt-2 leading-snug">
+            {s.headline}
+          </p>
+        )}
+
+        {/* Metadata bar */}
+        <p className="text-[11px] font-mono text-[#8B7B6B] mt-4 flex flex-wrap items-center gap-1.5">
+          <span>{s.job_title}</span>
+          {s.firm && (
+            <>
+              <span className="text-[#C4B5A5]">&middot;</span>
+              <span>{s.firm}</span>
+            </>
+          )}
+          {s.specialism && (
+            <>
+              <span className="text-[#C4B5A5]">&middot;</span>
+              <span>{s.specialism}</span>
+            </>
+          )}
+        </p>
+
+        {/* Profile section */}
+        <div className="mt-6">
+          <h4 className="text-[11px] font-mono uppercase tracking-wider text-[#8B7B6B] mb-2">
+            Profile
+          </h4>
+          <p className="text-[14px] font-sans text-[#3D3530] leading-[1.7]">
+            {s.paragraph}
+          </p>
+        </div>
+
+        {/* Why they're in the spotlight - news hook block (clickable) */}
+        {primaryUrl && primaryLabel && (
+          <div className="mt-6 bg-[#F5F0EA] border-l-4 border-[#A0522D] rounded-r-md p-4">
+            <h4 className="text-[11px] font-mono uppercase tracking-wider text-[#6B5B4F] mb-2">
+              Why they&rsquo;re in the spotlight
+            </h4>
+            <a
+              href={primaryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-[13px] font-sans italic text-[#A0522D] hover:text-[#8B4513] hover:underline transition-colors leading-relaxed"
+            >
+              <span>{primaryLabel}</span>
+              <span aria-hidden="true">&rarr;</span>
+            </a>
+            {showSecondarySource && s.source_evidence && (
+              <a
+                href={s.source_evidence}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block mt-2 text-[11px] font-mono italic text-[#8B7B6B] hover:text-[#A0522D] transition-colors"
+              >
+                Source: {domainFromUrl(s.source_evidence)} &rarr;
+              </a>
+            )}
+          </div>
+        )}
+
+        {/* LinkedIn profile link */}
+        {s.linkedin_url && (
+          <a
+            href={s.linkedin_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 mt-6 text-[12px] font-mono text-[#0A66C2] hover:text-[#004182] transition-colors"
+          >
+            <Linkedin className="w-4 h-4" />
+            <span>View on LinkedIn</span>
+          </a>
+        )}
+
+        {/* Share buttons */}
+        <SpotlightShareButtons spotlight={s} slug={slug} />
+
+        {/* Permanent link to dedicated profile page (only shown on archive view) */}
+        {!standalone && (
+          <div className="mt-4 pt-3 border-t border-[#F0E8E0]">
+            <Link
+              href={`/spotlight/${slug}`}
+              className="text-[11px] font-mono text-[#8B7B6B] hover:text-[#A0522D] transition-colors"
+            >
+              View full profile &rarr;
+            </Link>
+          </div>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/components/spotlight-share.tsx
+++ b/components/spotlight-share.tsx
@@ -3,31 +3,21 @@
 import { useState } from "react"
 import type { Spotlight } from "@/lib/queries"
 
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-}
-
 export function SpotlightShareButtons({ spotlight, slug }: { spotlight: Spotlight; slug: string }) {
   const [copied, setCopied] = useState(false)
-  
-  const shareUrl = `https://into.tax/spotlight#${slug}`
+
+  // Permanent per-profile URL. Replaces the old hash-anchor share pattern so
+  // LinkedIn / X previews resolve to a single profile page, not the archive index.
+  const shareUrl = `https://into.tax/spotlight/${slug}`
   const encodedUrl = encodeURIComponent(shareUrl)
-  
-  // LinkedIn share includes summary in URL
-  const linkedInTitle = encodeURIComponent(`${spotlight.person_name} - into.tax Spotlight`)
-  const linkedInSummary = encodeURIComponent(
-    spotlight.headline || `${spotlight.person_name}, ${spotlight.job_title}${spotlight.firm ? ` at ${spotlight.firm}` : ''}`
-  )
+
   const linkedInShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`
-  
+
   const xText = encodeURIComponent(
-    `${spotlight.person_name} featured in this week's into.tax In the Spotlight${spotlight.specialism ? ` for their work in ${spotlight.specialism}` : ''} 🔦`
+    `${spotlight.person_name} featured in this week's into.tax In the Spotlight${spotlight.specialism ? ` for their work in ${spotlight.specialism}` : ''} \u{1F526}`
   )
   const xShareUrl = `https://x.com/intent/tweet?text=${xText}&url=${encodedUrl}`
-  
+
   const handleCopyLink = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl)
@@ -37,11 +27,10 @@ export function SpotlightShareButtons({ spotlight, slug }: { spotlight: Spotligh
       console.error("Failed to copy link:", err)
     }
   }
-  
+
   return (
     <div className="flex items-center gap-2 mt-4 pt-4 border-t border-[#F0E8E0]">
       <span className="text-[10px] font-mono text-[#A0A0A0] mr-1">Share:</span>
-      
       <a
         href={linkedInShareUrl}
         target="_blank"
@@ -50,7 +39,6 @@ export function SpotlightShareButtons({ spotlight, slug }: { spotlight: Spotligh
       >
         LinkedIn
       </a>
-      
       <a
         href={xShareUrl}
         target="_blank"
@@ -59,7 +47,6 @@ export function SpotlightShareButtons({ spotlight, slug }: { spotlight: Spotligh
       >
         Share on X
       </a>
-      
       <button
         onClick={handleCopyLink}
         className="px-2.5 py-1 text-[10px] font-mono text-[#8B7B6B] bg-[#F5F0EA] rounded-full hover:bg-[#A0522D] hover:text-white transition-colors"
@@ -72,22 +59,22 @@ export function SpotlightShareButtons({ spotlight, slug }: { spotlight: Spotligh
 
 export function ShareThisWeekButton({ spotlights }: { spotlights: Spotlight[] }) {
   const [copied, setCopied] = useState(false)
-  
+
   const names = spotlights.map(s => s.person_name)
   const shareUrl = "https://into.tax/spotlight"
   const encodedUrl = encodeURIComponent(shareUrl)
-  
+
   // Format names: "name1, name2, name3, name4, and name5"
-  const formattedNames = names.length > 1 
+  const formattedNames = names.length > 1
     ? `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`
     : names[0] || ""
-  
+
   const shareText = `This week's into.tax In the Spotlight features ${formattedNames}.`
   const encodedText = encodeURIComponent(shareText)
-  
+
   const linkedInShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`
   const xShareUrl = `https://x.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`
-  
+
   const handleCopyLink = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl)
@@ -97,11 +84,10 @@ export function ShareThisWeekButton({ spotlights }: { spotlights: Spotlight[] })
       console.error("Failed to copy link:", err)
     }
   }
-  
+
   return (
     <div className="inline-flex items-center gap-2 px-4 py-2 bg-[#F5F0EA] rounded-lg border border-[#E8DFD6]">
       <span className="text-[11px] font-mono text-[#6B5B4F]">Share this week:</span>
-      
       <a
         href={linkedInShareUrl}
         target="_blank"
@@ -110,7 +96,6 @@ export function ShareThisWeekButton({ spotlights }: { spotlights: Spotlight[] })
       >
         LinkedIn
       </a>
-      
       <a
         href={xShareUrl}
         target="_blank"
@@ -119,7 +104,6 @@ export function ShareThisWeekButton({ spotlights }: { spotlights: Spotlight[] })
       >
         Share on X
       </a>
-      
       <button
         onClick={handleCopyLink}
         className="px-2.5 py-1 text-[10px] font-mono text-[#8B7B6B] bg-white rounded-full hover:bg-[#A0522D] hover:text-white transition-colors border border-[#E8DFD6]"

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -7,6 +7,17 @@ function createClient() {
   return createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY)
 }
 
+/**
+ * Shared slugify used by route, sitemap, share buttons, and spotlight cards.
+ * Must remain a single source of truth — changing this invalidates existing URLs.
+ */
+export function slugifyName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
 export type Article = {
   id: string
   title: string
@@ -49,6 +60,8 @@ export type Spotlight = {
   specialism: string | null
   paragraph: string
   source_evidence: string | null
+  news_hook_url: string | null
+  news_hook_label: string | null
   linkedin_url: string | null
   issue_date: string
   published: boolean
@@ -83,7 +96,6 @@ export async function getWireArticles() {
     .select("*")
     .order("published_at", { ascending: false })
     .limit(30)
-
   return data || []
 }
 
@@ -115,7 +127,6 @@ export async function getTrendingArticles() {
     .select("*")
     .order("views", { ascending: false })
     .limit(5)
-
   return data || []
 }
 
@@ -146,7 +157,6 @@ export async function getArticlesByCategory(category: string) {
     .select("*")
     .eq("category", category)
     .order("published_at", { ascending: false })
-
   return data || []
 }
 
@@ -160,7 +170,6 @@ export async function getArticlesByTag(tag: string) {
     .select("*")
     .contains("tags", [tag])
     .order("published_at", { ascending: false })
-
   return data || []
 }
 
@@ -177,7 +186,6 @@ export async function getGovernanceArticles() {
     .contains("tags", ["Compliance"])
     .order("published_at", { ascending: false })
     .limit(3)
-
   return data || []
 }
 
@@ -192,12 +200,12 @@ export async function getSpotlights(limit = 5) {
     .eq("published", true)
     .order("issue_date", { ascending: false })
     .limit(limit)
-
   return data || []
 }
 
 /**
  * All spotlight entries for archive page, grouped by issue_date.
+ * Returns only published entries for public archive display.
  */
 export async function getAllSpotlights() {
   const supabase = createClient()
@@ -206,8 +214,32 @@ export async function getAllSpotlights() {
     .select("*")
     .eq("published", true)
     .order("issue_date", { ascending: false })
-
   return data || []
+}
+
+/**
+ * ALL spotlight entries regardless of published status.
+ * Used by sitemap and by the [slug] route so that every profile ever featured
+ * retains a permanent, indexable URL even after rotation.
+ */
+export async function getEverySpotlight(): Promise<Spotlight[]> {
+  const supabase = createClient()
+  const { data } = await supabase
+    .from("spotlight")
+    .select("*")
+    .order("issue_date", { ascending: false })
+  return data || []
+}
+
+/**
+ * Look up a single spotlight by slugified person_name.
+ * Matches regardless of published status — fetches every row and compares
+ * slugs in memory so the slug algorithm always matches the route.
+ * Returns null if no row matches.
+ */
+export async function getSpotlightBySlug(slug: string): Promise<Spotlight | null> {
+  const all = await getEverySpotlight()
+  return all.find(s => slugifyName(s.person_name) === slug) || null
 }
 
 /**
@@ -221,6 +253,7 @@ export async function getFilteredArticles(options: {
   limit?: number
 }) {
   const supabase = createClient()
+
   let query = supabase
     .from("articles")
     .select("*")


### PR DESCRIPTION
Closes #8.

## What this changes

Each Spotlight profile now has its own indexable URL at `/spotlight/{slug}` with proper metadata, OG tags, and schema.org/Person JSON-LD. The archive at `/spotlight` is unchanged visually but now uses the extracted `<SpotlightCard>` component.

Share buttons now produce permanent `/spotlight/{slug}` URLs rather than `/spotlight#{slug}` hash anchors.

The "Why they're in the spotlight" block now renders as a proper clickable link (news_hook_url + news_hook_label precedence, source_evidence fallback, hidden if both null). A secondary "Source: {domain} →" line appears when source_evidence is distinct from the news hook.

## What this does NOT change

- `/api/spotlight/*` endpoints untouched
- `spotlight_rotation_log`, `spotlight_pool` tables untouched
- Email tracking fields untouched
- Existing `/spotlight#alun-oliver` type URLs still work (archive page + client-side scroll via ScrollToHash)

## Database

Schema migration and data population were already applied before this PR opened. The `spotlight` table has `news_hook_url` / `news_hook_label` columns, and all 5 current profiles have them populated with verified URLs. Code here simply reads those columns.

## Acceptance (post-deploy)

- [ ] `/spotlight/alun-oliver` returns 200
- [ ] `/spotlight/adam-owens` returns 200
- [ ] `/spotlight/paul-aplin` returns 200
- [ ] `/spotlight/penny-cogher` returns 200
- [ ] `/spotlight/sophie-dworetzsky` returns 200
- [ ] `/spotlight/no-such-person` returns 404
- [ ] `/spotlight` index still renders all 5 current profiles
- [ ] `/spotlight#alun-oliver` still works (backwards-compat)
- [ ] `/sitemap.xml` contains 5 new spotlight URLs
- [ ] Profile page source includes `<script type="application/ld+json">` with schema.org/Person
