### PR TITLE
feat: add subscribe CTA to Spotlight profile and archive pages

### DIFF
--- a/app/spotlight/[slug]/page.tsx
+++ b/app/spotlight/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Masthead } from "@/components/masthead"
 import { DeadlineTicker } from "@/components/deadline-ticker"
 import { SpotlightCard } from "@/components/spotlight-card"
+import { EmailCapture } from "@/components/sidebar"
 import { getSpotlightBySlug, getKeyDates, slugifyName } from "@/lib/queries"
 
 export const revalidate = 0
@@ -127,6 +128,11 @@ export default async function SpotlightProfilePage({ params }: RouteParams) {
           slug={slug}
           standalone
         />
+
+        {/* Subscribe CTA — appears after the profile, when the reader is primed */}
+        <div className="mt-12 max-w-md mx-auto">
+          <EmailCapture />
+        </div>
 
         <div className="mt-16 pt-8 border-t border-[#E8DFD6] text-center">
           <Link

--- a/app/spotlight/page.tsx
+++ b/app/spotlight/page.tsx
@@ -5,6 +5,7 @@ import { getKeyDates } from "@/lib/queries"
 import Link from "next/link"
 import { ShareThisWeekButton } from "@/components/spotlight-share"
 import { SpotlightCard } from "@/components/spotlight-card"
+import { EmailCapture } from "@/components/sidebar"
 import { ScrollToHash } from "@/components/scroll-to-hash"
 
 export const revalidate = 0
@@ -132,7 +133,12 @@ export default async function SpotlightArchivePage() {
           </div>
         )}
 
-        <div className="mt-16 pt-8 border-t border-[#E8DFD6] text-center">
+        {/* Subscribe CTA */}
+        <div className="mt-16 max-w-md mx-auto">
+          <EmailCapture />
+        </div>
+
+        <div className="mt-12 pt-8 border-t border-[#E8DFD6] text-center">
           <Link
             href="/"
             className="text-[12px] font-mono text-[#8B7B6B] hover:text-[#A0522D] transition-colors"


### PR DESCRIPTION
Adds the existing `<EmailCapture />` component to `/spotlight/[slug]` (between the profile card and back-to-home link) and to the `/spotlight` archive page (below the cards list).

## Change
- Profile page: CTA in the **primed-reader position** — after they've just read the profile.
- Archive page: CTA below the cards list.
- Reuses the existing component — same copy (`Weekly Digest / The week in UK tax. / Curated from 120+ sources. Every Friday morning.`), same `/api/subscribe` endpoint, same BLOCKED_DOMAINS firm-email rule.

## Why this vs. asking in the outreach email or auto-subscribing
Auto-subscribing the five spotlighted professionals without affirmative consent would be a UK GDPR breach. Asking them to subscribe inside the outreach email would collapse the no-ask integrity of that message. The correct fix is on the landing page itself.

## Acceptance
- [ ] `/spotlight/adam-owens` (or any slug) renders the dark `Weekly Digest` card below the profile
- [ ] `/spotlight` archive renders the same card below the cards list
- [ ] Submitting a firm email still POSTs to `/api/subscribe` successfully
- [ ] Submitting a blocked domain (e.g. `test@gmail.com`) shows the existing client-side error